### PR TITLE
Disabled breaking call to api method EdsDeleteDirectoryItem

### DIFF
--- a/src/ofxCanon/Device.cpp
+++ b/src/ofxCanon/Device.cpp
@@ -335,8 +335,13 @@ namespace ofxCanon {
 					, "Download directory item");
 				ERROR_THROW(EdsDownloadComplete(directoryItem)
 					, "Download complete");
-				WARNING(EdsDeleteDirectoryItem(directoryItem)
-					, "Delete directory item");
+				
+				// NOTE: Using EDSDK 13.12.1 Using EdsDeleteDirectoryItem on an in memory 
+				// item first hang the camera for several seconds and then crashed the live view
+				// following the reference document/pdf a DeleteDirectory item is not needed (at least)
+				// it is not mentioned in the document (also not as change from previous API versions)
+				//WARNING(EdsDeleteDirectoryItem(directoryItem)
+				//	, "Delete directory item");
 			}
 
 			// NOTE : The Canon SDK does not provide decoding of RAW images for all its cameras, especially in 64bit


### PR DESCRIPTION
Hello, 

in the process of getting the code base run on EDSDK 13.12.1 I found that the call to EdsDeleteDirectoryItem caused havok. Once run it first blocked the camera for several seconds and then brought the liveview to halt. 

I've checked the reference document the call should not be necessary when dealing with in memory calls. Removing/disabling the line should be save for all versions as the document did not mention any changes to previous versions. 

Thanks!